### PR TITLE
[Fix] image-only posts

### DIFF
--- a/save_markdown.py
+++ b/save_markdown.py
@@ -72,7 +72,7 @@ def save_posts_to_markdown(posts_data, markdown_dir, image_dir):
         )  # Add star and reply count
         post_text = post.get("text", "")
         if post_text is None:
-            continue
+            post_text = ""
         post_text_with_double_newlines = post_text.replace("\n", "\n")
         md_lines.append(post_text_with_double_newlines)
         # If image, copy image and add image reference with relative path


### PR DESCRIPTION
对之前PR的一个修正，修复了image-only post的保存功能（如#5930931, 之前是直接continue跳过）